### PR TITLE
Fix medical diagnosis data setup paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 apps/src/sage/apps/medical_diagnosis/data/processed/*
+apps/src/sage/apps/medical_diagnosis/data/test_results/*
+apps/src/sage/apps/medical_diagnosis/data/medical/lumbar-spine-mri/cache/*
+apps/src/sage/apps/medical_diagnosis/data/medical/lumbar-spine-mri/dataset_info.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
     "python-envs.defaultEnvManager": "ms-python.python:conda",
     "python-envs.defaultPackageManager": "ms-python.python:conda",
-    "python-envs.pythonProjects": []
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:conda",
+            "packageManager": "ms-python.python:conda"
+        }
+    ]
 }

--- a/apps/src/sage/apps/medical_diagnosis/agents/diagnostic_agent.py
+++ b/apps/src/sage/apps/medical_diagnosis/agents/diagnostic_agent.py
@@ -59,7 +59,7 @@ class DiagnosticAgent:
             },
             "services": {
                 "sagellm": {"enabled": True, "gpu_memory_utilization": 0.9},
-                "embedding": {"method": "hf", "cache_enabled": True},
+                "embedding": {"method": "hash", "cache_enabled": True},
                 "vector_db": {"collection_name": "lumbar_spine_cases", "top_k": 5},
             },
         }

--- a/apps/src/sage/apps/medical_diagnosis/config/agent_config.yaml
+++ b/apps/src/sage/apps/medical_diagnosis/config/agent_config.yaml
@@ -28,7 +28,7 @@ services:
 
   # Embedding服务配置
   embedding:
-    method: hf
+    method: hash
     cache_enabled: true
     normalize: true
     batch_size: 32

--- a/apps/src/sage/apps/medical_diagnosis/run_diagnosis.py
+++ b/apps/src/sage/apps/medical_diagnosis/run_diagnosis.py
@@ -16,6 +16,9 @@ from typing import Any
 from sage.apps.medical_diagnosis.agents import DiagnosticAgent
 
 
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "config" / "agent_config.yaml"
+
+
 def check_and_setup_data(auto_setup: bool = False):
     """检查数据是否存在，如果不存在则自动下载和准备"""
     # 获取当前脚本所在目录
@@ -120,7 +123,7 @@ def parse_args():
         "--config",
         "-c",
         type=str,
-        default="examples/medical_diagnosis/config/agent_config.yaml",
+        default=str(DEFAULT_CONFIG_PATH),
         help="配置文件路径",
     )
 

--- a/apps/src/sage/apps/medical_diagnosis/scripts/prepare_data.py
+++ b/apps/src/sage/apps/medical_diagnosis/scripts/prepare_data.py
@@ -15,9 +15,8 @@ from sklearn.model_selection import train_test_split
 # Note: This script assumes sage-apps package is installed
 # Install with: cd sage-apps && pip install -e .
 
-# 查找项目根目录
-_current_file = Path(__file__).resolve()
-project_root = _current_file.parent.parent.parent.parent.parent.parent  # 到 sage-examples 根目录
+# 当前 medical_diagnosis 应用目录
+APP_DIR = Path(__file__).resolve().parent.parent
 
 
 # 疾病类别映射 (模拟)
@@ -123,8 +122,8 @@ def generate_mock_report(label: int, patient_info: dict) -> str:
 def prepare_dataset():
     """准备数据集"""
 
-    dataset_path = project_root / "data" / "medical" / "lumbar-spine-mri" / "cache"
-    output_dir = project_root / "examples" / "medical_diagnosis" / "data" / "processed"
+    dataset_path = APP_DIR / "data" / "medical" / "lumbar-spine-mri" / "cache"
+    output_dir = APP_DIR / "data" / "processed"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     print("=" * 80)

--- a/apps/src/sage/apps/medical_diagnosis/setup_data.sh
+++ b/apps/src/sage/apps/medical_diagnosis/setup_data.sh
@@ -6,6 +6,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DATA_DIR="$SCRIPT_DIR/data/processed"
+PYTHON_BIN="${PYTHON_BIN:-python}"
 
 echo "=========================================="
 echo "医疗诊断数据集自动设置"
@@ -40,7 +41,7 @@ echo ""
 
 # 1. 安装必要的依赖
 echo "1️⃣  检查Python依赖..."
-pip install -q huggingface_hub datasets pillow scikit-learn || {
+"$PYTHON_BIN" -m pip install -q huggingface_hub datasets pillow scikit-learn || {
     echo "❌ 依赖安装失败"
     exit 1
 }
@@ -49,7 +50,7 @@ echo "   ✓ 依赖已安装"
 # 2. 下载数据集
 echo ""
 echo "2️⃣  下载腰椎MRI数据集..."
-python3 "$PROJECT_ROOT/scripts/download_lumbar_dataset.py" || {
+"$PYTHON_BIN" "$SCRIPT_DIR/scripts/download_lumbar_dataset.py" || {
     echo "❌ 数据集下载失败"
     exit 1
 }
@@ -58,7 +59,7 @@ echo "   ✓ 数据集下载完成"
 # 3. 预处理数据
 echo ""
 echo "3️⃣  预处理数据集..."
-python3 "$SCRIPT_DIR/scripts/prepare_data.py" || {
+"$PYTHON_BIN" "$SCRIPT_DIR/scripts/prepare_data.py" || {
     echo "❌ 数据预处理失败"
     exit 1
 }
@@ -71,7 +72,7 @@ if [ -f "$DATA_DIR/train_index.json" ] && [ -f "$DATA_DIR/test_index.json" ]; th
     echo "   ✓ 数据集验证成功"
 
     # 显示统计信息
-    python3 -c "
+    "$PYTHON_BIN" -c "
 import json
 with open('$DATA_DIR/stats.json', 'r') as f:
     stats = json.load(f)
@@ -93,6 +94,6 @@ echo ""
 echo "✅ 数据集设置完成！"
 echo ""
 echo "可以开始使用:"
-echo "  python examples/medical_diagnosis/test_diagnosis.py --mode single"
-echo "  python examples/medical_diagnosis/run_diagnosis.py --interactive"
+echo "  python apps/tests/medical_diagnosis/test_diagnosis.py --mode single"
+echo "  python examples/run_medical_diagnosis.py --interactive"
 echo ""


### PR DESCRIPTION
## Summary

Fix the medical diagnosis demo so data setup and tests work correctly in the existing configured environment.

## Changes

- fix `run_diagnosis.py` to use the in-package default config path
- fix `prepare_data.py` to read/write data under the medical diagnosis app directory
- fix `setup_data.sh` to reuse the current Python interpreter instead of drifting to another environment
- update medical diagnosis embedding config from `hf` to `hash`
- ignore generated medical test artifacts and local dataset cache

## Validation

Ran the following successfully in the existing conda environment:

- `python -m pytest -q apps/tests/test_medical_diagnosis.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_knowledge_base.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_image_quality.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_image_analyzer.py`
- `SAGE_ENABLE_MEDICAL_DIAGNOSIS=1 python -m pytest -q apps/tests/medical_diagnosis/test_diagnosis.py`

Also verified:

- `python examples/run_medical_diagnosis.py`

## Notes

- The example still falls back when the local LLM service is unavailable, but the diagnosis flow completes correctly.

## 变更概述

修复 medical diagnosis 示例中的数据准备与路径问题，使其能够在现有已配置环境中正确完成数据生成、测试执行和示例运行。

## 主要修改

- 修复 `run_diagnosis.py` 的默认配置路径，改为使用应用目录内的配置文件
- 修复 `prepare_data.py` 的数据读写路径，统一落到 medical diagnosis 应用目录下
- 修复 `setup_data.sh`，改为复用当前 Python 解释器，避免切到其他环境
- 将 medical diagnosis 的 embedding 配置从 `hf` 调整为 `hash`
- 补充忽略规则，避免将本地生成的数据缓存和测试产物误提交

## 验证结果

已在当前 conda 环境中完成以下验证：

- `python -m pytest -q apps/tests/test_medical_diagnosis.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_knowledge_base.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_image_quality.py`
- `python -m pytest -q apps/tests/medical_diagnosis/test_image_analyzer.py`
- `SAGE_ENABLE_MEDICAL_DIAGNOSIS=1 python -m pytest -q apps/tests/medical_diagnosis/test_diagnosis.py`

另外已验证：

- `python examples/run_medical_diagnosis.py`

## 说明

- 当本地 LLM 服务不可用时，示例仍会回退到模板报告生成，但整体诊断流程可以正常完成。
- 本次修改未创建新的虚拟环境，全部验证均基于现有 conda 环境完成。